### PR TITLE
Add is_run_ready.bash

### DIFF
--- a/scripts/is_run_backuped.bash
+++ b/scripts/is_run_backuped.bash
@@ -19,7 +19,7 @@ for RUN in ${BACKUP_DIR}/*; do
         echo -e "${RED}${RUN}${RESET}\t"
         continue
     else
-        echo -en "${RUN}\t"
+        echo -en "${GREEN}${RUN}${RESET}\t"
     fi
 
     # check size

--- a/scripts/is_run_ready.bash
+++ b/scripts/is_run_ready.bash
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+set -u
+
+IN_FILE=${1-/tmp/to_pdc}
+RUN_DIR=/home/hiseq.clinical/Runs/
+ENCRYPT_DIR=/home/hiseq.clinical/ENCRYPT/
+
+# COLORS
+RED="\033[0;31m"
+ORANGE="\033[0;33m"
+GREEN="\033[0;32m"
+RESET="\033[0m"
+
+for RUN in ${RUN_DIR}/*; do
+    RUN=${RUN##*/}
+
+    # check if run is ready for archiving
+    RTAComplete_found=$(find ${RUN_DIR}/${RUN} -maxdepth 1 -name RTAComplete.txt -mtime +5 | wc -l)
+    if [[ $RTAComplete_found -gt 0 ]]; then
+        if [[ ! -e ${ENCRYPT_DIR}/${RUN}_started ]]; then
+            echo -e "${RED}${RUN}${RESET}"
+        else
+            echo -e "${ORANGE}${RUN}${RESET}"
+        fi
+    else
+        echo "${RUN}"
+    fi
+done


### PR DESCRIPTION
Extended the way one can list the status of a rundir on the NAS:es.

This script will:
* run is_run_ready.bash on all NAS:es to list all runs that are eligable for archiving (but haven't and those that are in the process of being archived.

What already was added:
* generate a file listing all archived runs, their keys and the file sizes of both.
* run is_run_archived.bash on all NAS:es with the generated list as argument.

The output is coloured according to success (green), processing (yellow), and fail (red). Runs that are not ready for archiving are not colored at all.

* the run name (red: not present on pdc, yellow: in the process of being archived, white: not ready for archiving)
* the file size of the archive (red: possible error in archiving)
* the size difference in procent between the archive and the run folder (red: possible archiving error)
* whether or not the encryption key is present (present/not present)
* the file size of the key (red: not sized 607b)
