### PR TITLE
feat(overviewlog): Remove NAS-8 and NAS-10 from the overviewlog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+DEVELOP/
+.idea

--- a/scripts/overviewlog.bash
+++ b/scripts/overviewlog.bash
@@ -1,11 +1,11 @@
-#!/bin/bash
+#! /bin/bash
 #
 #    Usage: overview.bash
 #      run as hiseq.clinical 
 #      use screen or nohup
 #
 
-VERSION=3.12.1
+VERSION=3.12.2
 
 . /home/clinical/CONFIG/configuration.txt
 NOW=$(date +"%Y%m%d%H%M%S")
@@ -28,7 +28,7 @@ log "Logfile is ${LOGFILE}"
 log "Variables read in from /home/clinical/CONFIG/configuration.txt"
 log "               LOGDIR  -  ${LOGDIR}"
 
-declare -A SERVERS=( [clinical-db]=493G,/var [clinical-preproc]=/home [clinical-nas-1]=/home [clinical-nas-2]=/home [seq-nas-1]=/home [seq-nas-3]=/home [nas-8]=/home [nas-9]=/home [nas-10]=/home [hasta]=/home )
+declare -A SERVERS=( [clinical-db]=493G,/var [clinical-preproc]=/home [clinical-nas-1]=/home [clinical-nas-2]=/home [seq-nas-1]=/home [seq-nas-3]=/home [nas-9]=/home [hasta]=/home )
 
 for SERVER in "${!SERVERS[@]}"; do
   DIRS=( $( echo ${SERVERS[$SERVER]} | sed -e 's/,/ /g' ) )


### PR DESCRIPTION
### This PR adds | fixes:
- Remove NAS-8 and NAS-10 from the servers to monitor as we do not currently use them

**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
-

### Expected outcome:
- [ ]

### Review:
- [x] Code approved by @barrystokman 
- [ ] Tests executed by
- [x] "Merge and deploy" approved by @barrystokman 

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
