### PR TITLE
Fix: check that encryption is already running failing due to gpg-agent daemon

### DIFF
--- a/scripts/checkfornewrun.bash
+++ b/scripts/checkfornewrun.bash
@@ -39,7 +39,7 @@ trap finish ERR
 # MAIN #
 ########
 
-if pgrep rsync || pgrep gpg; then
+if pgrep rsync || pgrep -x gpg; then
     log "Skipping archiving - Other runs are syncing"
     exit
 fi


### PR DESCRIPTION
This PR fixes flowcell encryption being blocked by NGI's gpg-agent daemon. 
- 

**How to prepare for test**:
N/A

### How to test:
N/A

### Expected outcome:
checkfornewrun.bash will start the encryption process, even if `gpg-agent` is running, but waits if `gpg` is already running.

### Review:
- [ ] Code approved by
- [ ] Tests executed by N/A
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
