### PR TITLE
Fix(PDC): remove flag to fail on unset variable

### DIFF
--- a/scripts/retrieve_decrypt.bash
+++ b/scripts/retrieve_decrypt.bash
@@ -2,7 +2,7 @@
 
 # retrieves and transfers a file from PDC
 
-set -eu -o pipefail
+set -e -o pipefail
 
 ########
 # VARS #


### PR DESCRIPTION
### This PR fixes:
- fail do fetch FC due to unset passphrase

**How to prepare for test**:
- [x] `ssh` to nas-9
- [x] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
- fetch fc

### Expected outcome:
- [x] success!

### Review:
- [x] Code approved by BS
- [x] Tests executed by PG
- [x] "Merge and deploy" approved by PG

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

- [ ] Inform to BS, MH