### PR TITLE
Feat semaphore safe retrieve

### DIFF
--- a/scripts/retrieve_decrypt_safe_mode.bash
+++ b/scripts/retrieve_decrypt_safe_mode.bash
@@ -126,10 +126,10 @@ MAX_AGE=720
 if [[ ! -f ${SEMAPHORE} ]]; then
   log_exc touch ${SEMAPHORE}
 elif [[ $(find ${SEMAPHORE} -maxdepth 0 -cmin -${MAX_AGE}) ]]; then
-  log "Semaphore file '${SEMAPHORE}' exists, quiting"
+  log "Semaphore file '${TMP_DIR}/${SEMAPHORE}' exists. Fetching of flowcell already in progress. Quiting"
   exit 0
 else
-  log "Semaphore file '${SEMAPHORE}' exists but is older than ${MAX_AGE} minutes, quiting with error status"
+  log "Semaphore file '${TMP_DIR}/${SEMAPHORE}' exists but is older than ${MAX_AGE} minutes, quiting with error status"
   exit 1
 fi
 


### PR DESCRIPTION
### This PR fixes:
- The issue that allows the retrieval to start multiple instances that interferes with each other 

**How to prepare for test**:
- [x] `ssh` to PDC-nas
- [x] clone this repo somewhere
- [x] checkout this branch

### How to test:
- Run the changed script with & at the end to start an retrieval in the background
- Run the script again 

### Expected outcome:
- [x] the first script should continue uninterrupted and the second invocation should exit upon detection of the first 

### Review:
- [x] Code approved by HS
- [x] Tests executed by PG
- [x] "Merge and deploy" approved by PG

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
