### PR TITLE
don't exit decryption if exit code = 2

### DIFF
--- a/scripts/retrieve_decrypt_safe_mode.bash
+++ b/scripts/retrieve_decrypt_safe_mode.bash
@@ -159,7 +159,7 @@ TMP_DECRYPTED_FILE=${DECRYPTED_FILE}.tmp
 set +e # temporarily suspend exiting on any error
 if [[ ! -f ${DECRYPTED_FILE} ]]; then
   log "gpg --cipher-algo aes256 --passphrase-file <(gpg --cipher-algo aes256 --passphrase <NOT-SHOWN> --batch --decrypt ${KEY_FILE}) --batch --decrypt ${RUN_FILE} > ${TMP_DECRYPTED_FILE}"
-  gpg --cipher-algo aes256 --passphrase-file <(gpg --cipher-algo aes256 --passphrase "${PASSPHRASE}" --batch --decrypt ${KEY_FILE}) --batch --decrypt ${RUN_FILE} > ${TMP_DECRYPTED_FILE}; EXIT_STATUS=$?
+  EXIT_STATUS=gpg --cipher-algo aes256 --passphrase-file <(gpg --cipher-algo aes256 --passphrase "${PASSPHRASE}" --batch --decrypt ${KEY_FILE}) --batch --decrypt ${RUN_FILE} > ${TMP_DECRYPTED_FILE}
   if [ ${EXIT_STATUS} -ne 0 ] && [ ${EXIT_STATUS} -ne 2 ]; then
     log "Exiting decryption with status code ${EXIT_STATUS}!"
     remove_file ${TMP_DECRYPTED_FILE}

--- a/scripts/retrieve_decrypt_safe_mode.bash
+++ b/scripts/retrieve_decrypt_safe_mode.bash
@@ -157,13 +157,18 @@ fi
 # STEP 3: decrypt run
 TMP_DECRYPTED_FILE=${DECRYPTED_FILE}.tmp
 trap "remove_file ${TMP_DECRYPTED_FILE}; error" ERR
+set +e # temporarily suspend exiting on any error
 if [[ ! -f ${DECRYPTED_FILE} ]]; then
   log "gpg --cipher-algo aes256 --passphrase-file <(gpg --cipher-algo aes256 --passphrase <NOT-SHOWN> --batch --decrypt ${KEY_FILE}) --batch --decrypt ${RUN_FILE} > ${TMP_DECRYPTED_FILE}"
   gpg --cipher-algo aes256 --passphrase-file <(gpg --cipher-algo aes256 --passphrase "${PASSPHRASE}" --batch --decrypt ${KEY_FILE}) --batch --decrypt ${RUN_FILE} > ${TMP_DECRYPTED_FILE}
-  mv ${TMP_DECRYPTED_FILE} ${DECRYPTED_FILE}
+  mv ${TMP_DECRYPTED_FILE} ${DECRYPTED_FILE}; EXIT_STATUS=$?
+  if [ "${EXIT_STATUS}" -ne 0 ] && [ "${EXIT_STATUS}" -ne 2 ]; then
+    exit "${EXIT_STATUS}" # exit if exit code of decryption is not either 0 or 2, where 2 means `gpg: WARNING: encrypted message has been manipulated!`
+  fi
 else
   log "Found decrypted run file ${DECRYPTED_FILE}, skipping gpg decrypting run"
 fi
+set -e # resume exiting on any error
 
 # STEP 4: decompress run
 TMP_RUN_NAME=${RUN_NAME}.tmp

--- a/scripts/retrieve_decrypt_safe_mode.bash
+++ b/scripts/retrieve_decrypt_safe_mode.bash
@@ -156,15 +156,16 @@ fi
 
 # STEP 3: decrypt run
 TMP_DECRYPTED_FILE=${DECRYPTED_FILE}.tmp
-trap "remove_file ${TMP_DECRYPTED_FILE}; error" ERR
 set +e # temporarily suspend exiting on any error
 if [[ ! -f ${DECRYPTED_FILE} ]]; then
   log "gpg --cipher-algo aes256 --passphrase-file <(gpg --cipher-algo aes256 --passphrase <NOT-SHOWN> --batch --decrypt ${KEY_FILE}) --batch --decrypt ${RUN_FILE} > ${TMP_DECRYPTED_FILE}"
-  gpg --cipher-algo aes256 --passphrase-file <(gpg --cipher-algo aes256 --passphrase "${PASSPHRASE}" --batch --decrypt ${KEY_FILE}) --batch --decrypt ${RUN_FILE} > ${TMP_DECRYPTED_FILE}
-  mv ${TMP_DECRYPTED_FILE} ${DECRYPTED_FILE}; EXIT_STATUS=$?
-  if [ "${EXIT_STATUS}" -ne 0 ] && [ "${EXIT_STATUS}" -ne 2 ]; then
-    exit "${EXIT_STATUS}" # exit if exit code of decryption is not either 0 or 2, where 2 means `gpg: WARNING: encrypted message has been manipulated!`
+  gpg --cipher-algo aes256 --passphrase-file <(gpg --cipher-algo aes256 --passphrase "${PASSPHRASE}" --batch --decrypt ${KEY_FILE}) --batch --decrypt ${RUN_FILE} > ${TMP_DECRYPTED_FILE}; EXIT_STATUS=$?
+  if [ ${EXIT_STATUS} -ne 0 ] && [ ${EXIT_STATUS} -ne 2 ]; then
+    log "Exiting decryption with status code ${EXIT_STATUS}!"
+    remove_file ${TMP_DECRYPTED_FILE}
+    exit ${EXIT_STATUS} # exit if exit code of decryption is not either 0 or 2, where 2 means `gpg: WARNING: encrypted message has been manipulated!`
   fi
+  mv ${TMP_DECRYPTED_FILE} ${DECRYPTED_FILE}
 else
   log "Found decrypted run file ${DECRYPTED_FILE}, skipping gpg decrypting run"
 fi

--- a/scripts/retrieve_decrypt_safe_mode.bash
+++ b/scripts/retrieve_decrypt_safe_mode.bash
@@ -159,7 +159,8 @@ TMP_DECRYPTED_FILE=${DECRYPTED_FILE}.tmp
 set +e # temporarily suspend exiting on any error
 if [[ ! -f ${DECRYPTED_FILE} ]]; then
   log "gpg --cipher-algo aes256 --passphrase-file <(gpg --cipher-algo aes256 --passphrase <NOT-SHOWN> --batch --decrypt ${KEY_FILE}) --batch --decrypt ${RUN_FILE} > ${TMP_DECRYPTED_FILE}"
-  EXIT_STATUS=gpg --cipher-algo aes256 --passphrase-file <(gpg --cipher-algo aes256 --passphrase "${PASSPHRASE}" --batch --decrypt ${KEY_FILE}) --batch --decrypt ${RUN_FILE} > ${TMP_DECRYPTED_FILE}
+  gpg --cipher-algo aes256 --passphrase-file <(gpg --cipher-algo aes256 --passphrase "${PASSPHRASE}" --batch --decrypt ${KEY_FILE}) --batch --decrypt ${RUN_FILE} > ${TMP_DECRYPTED_FILE}
+  EXIT_STATUS=$?
   if [ ${EXIT_STATUS} -ne 0 ] && [ ${EXIT_STATUS} -ne 2 ]; then
     log "Exiting decryption with status code ${EXIT_STATUS}!"
     remove_file ${TMP_DECRYPTED_FILE}


### PR DESCRIPTION
### This PR fixes:
Flowcelll retrieval erroring out due to warning: `gpg: WARNING: encrypted message has been manipulated!` This warning returns exit code 2 for the gpg command, so we need to continue the process even if the exit status of that command is 2.


**How to prepare for test**:
- [x] `ssh` to NAS-9
- [x] Clone this branch in a loctaion of your choice, for example `/home/hiseq.clinical/test_exitcode2/`

### How to test:
- [x] `bash test_exitcode2/backup/scripts/retrieve_decrypt_safe_mode.bash /home/hiseq.clinical/ENCRYPT/180202_ST-E00266_0270_BHHGL2CCXY.tar.gz.gpg localhost /home/hiseq.clinical/test_exitcode2/`

### Expected outcome:
- [x] decryption continues to decompression even after `gpg: WARNING: encrypted message has been manipulated!`

### Review:
- [x] Code approved by
- [x] Tests executed by @barrystokman 
- [x] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
