### PR TITLE
Removed rsync check, added remaining storage check

### DIFF
--- a/scripts/checkfornewrun.bash
+++ b/scripts/checkfornewrun.bash
@@ -12,6 +12,7 @@ INDIR=${1?'Need a directory to monitor'}
 OUTDIR=${2-/home/hiseq.clinical/ENCRYPT}
 REMOTE_OUTDIR=${3-rasta:/mnt/hds/proj/bioinfo/TO_PDC}
 MVDIR=/home/hiseq.clinical/BACKUP
+NAS=$(hostname)
 EMAILS=clinical-logwatch@scilifelab.se
 
 SCRIPTDIR=$(dirname $0)
@@ -30,7 +31,6 @@ log() {
 #########
 
 finish() {
-    NAS=$(hostname)
     echo "Error while backing up ${RUN} on ${NAS}" | mail -s "Error while backing up ${RUN} on ${NAS}" ${EMAILS}
 }
 trap finish ERR

--- a/scripts/checkfornewrun.bash
+++ b/scripts/checkfornewrun.bash
@@ -39,8 +39,15 @@ trap finish ERR
 # MAIN #
 ########
 
-if pgrep rsync || pgrep -x gpg; then
-    log "Skipping archiving - Other runs are syncing"
+if pgrep -x gpg; then
+    log "Skipping archiving - Other runs are undergoing encryption syncing"
+    exit
+fi
+
+PERCENTAGE_STORAGE_USED=$(df -h /home --output=pcent | awk '$0!~/Use/ {print $0}' | sed 's/\s//g' | sed 's/[%]//g')
+
+if [ ${PERCENTAGE_STORAGE_USED} -gt 75 ]; then
+    log "Skipping archiving - Storage is almost full"
     exit
 fi
 

--- a/scripts/checkfornewrun.bash
+++ b/scripts/checkfornewrun.bash
@@ -48,6 +48,7 @@ PERCENTAGE_STORAGE_USED=$(df -h /home --output=pcent | awk '$0!~/Use/ {print $0}
 
 if [ ${PERCENTAGE_STORAGE_USED} -gt 75 ]; then
     log "Skipping archiving - Storage is almost full"
+    echo "Skipping archiving - Storage is almost full on ${NAS} - ${PERCENTAGE_STORAGE_USED}%" | mail -s "Skipping archiving - Storage is almost full on ${NAS}" ${EMAILS}
     exit
 fi
 


### PR DESCRIPTION
### This PR adds and fixes:

- Start of encryption during sequencing to keep the process going and to clear out space
- Limit start of encryption to memory available - undergoing sequencing and encryption should be able to finish

**How to prepare for test**:
- [x] `ssh` to NAS's

### How to test:

- Check if correct percent usage is fetched.

### Expected outcome:

- [x] Percent usage fetched should be same as if checked for /home

### Review:
- [ ] Code approved by
- [x] Tests executed by @karlnyr 
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
